### PR TITLE
Define routes

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/user-event": "^12.8.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-router-dom": "^6.2.1",
         "react-scripts": "4.0.3",
         "web-vitals": "^1.1.2"
       },
@@ -11392,6 +11393,15 @@
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
       "license": "MIT"
     },
+    "node_modules/history": {
+      "version": "5.2.0",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/history/-/history-5.2.0.tgz",
+      "integrity": "sha1-fN0xz5usPF0x8JwjHJko+tAAe3w=",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -18720,6 +18730,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.2.1",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha1-viqXpgBs4dkSPCiTTmBPrvUUSKM=",
+      "license": "MIT",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.2.1",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha1-MuyBgpFS+7insEW/WToi6t8Bm+w=",
+      "license": "MIT",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -32354,6 +32390,14 @@
       "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4="
     },
+    "history": {
+      "version": "5.2.0",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/history/-/history-5.2.0.tgz",
+      "integrity": "sha1-fN0xz5usPF0x8JwjHJko+tAAe3w=",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -37498,6 +37542,23 @@
       "version": "0.8.3",
       "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha1-ch1GV2ctQAxePHXQY8SoX7LV1o8="
+    },
+    "react-router": {
+      "version": "6.2.1",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha1-viqXpgBs4dkSPCiTTmBPrvUUSKM=",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.2.1",
+      "resolved": "https://corporater.jfrog.io/corporater/api/npm/npm/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha1-MuyBgpFS+7insEW/WToi6t8Bm+w=",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
+      }
     },
     "react-scripts": {
       "version": "4.0.3",

--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2"
   },

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -19,6 +19,8 @@ import {
 import { Articles } from './components/articles/articles'
 import { AddArticle } from './components/articles/addArticle'
 import { Profile } from './components/profile/profile'
+import { NotFound } from './components/pages/notFound'
+import { PostRouteContainer } from './containers/post/postRoute'
 
 function App() {
 
@@ -34,7 +36,7 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path='*' element={
+        <Route path='/' element={
           <div className='App'>
             <HeaderContainer page={page} onPageChange={setPage} onPageTitleChange={setPageTitle} />
             <Divider />
@@ -50,6 +52,9 @@ function App() {
         <Route path={ROUTES.PROFILE} element={
           <Profile pageTitle={PROFILE_PAGE_TITLE} />
         } />
+        <Route path='/post/:id' element={<PostRouteContainer />} />
+        <Route path='/post/*' element={<NotFound />} />
+        <Route path='*' element={<NotFound />} />
       </Routes>
 
     </BrowserRouter>

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -21,6 +21,7 @@ import { AddArticle } from './components/articles/addArticle'
 import { Profile } from './components/profile/profile'
 import { NotFound } from './components/pages/notFound'
 import { PostRouteContainer } from './containers/post/postRoute'
+import { DateRouteContainer } from './containers/post/dateRoute'
 
 function App() {
 
@@ -54,6 +55,8 @@ function App() {
         } />
         <Route path='/post/:id' element={<PostRouteContainer />} />
         <Route path='/post/*' element={<NotFound />} />
+        <Route path='/date/:date' element={<DateRouteContainer />} />
+        <Route path='/date/*' element={<NotFound />} />
         <Route path='*' element={<NotFound />} />
       </Routes>
 

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -3,19 +3,56 @@ import { HeaderContainer } from './containers/header/header'
 import { BodyContainer } from './containers/body/body'
 import { useState } from 'react'
 import Divider from '@mui/material/Divider'
-import { ARTICLES_PAGE, ARTICLES_PAGE_TITLE } from './constants'
+import {
+  ADD_ARTICLE_PAGE,
+  ADD_ARTICLE_PAGE_TITLE,
+  ARTICLES_PAGE,
+  ARTICLES_PAGE_TITLE,
+  PROFILE_PAGE,
+  PROFILE_PAGE_TITLE
+} from './constants'
+import {
+  BrowserRouter,
+  Routes,
+  Route
+} from 'react-router-dom'
+import { Articles } from './components/articles/articles'
+import { AddArticle } from './components/articles/addArticle'
+import { Profile } from './components/profile/profile'
 
 function App() {
+
+  const ROUTES = {
+    ARTICLES: '/' + ARTICLES_PAGE,
+    ADD_ARTICLE: '/' + ADD_ARTICLE_PAGE,
+    PROFILE: '/' + PROFILE_PAGE
+  }
 
   const [page, setPage] = useState(ARTICLES_PAGE)
   const [pageTitle, setPageTitle] = useState(ARTICLES_PAGE_TITLE)
 
   return (
-    <div className='App'>
-      <HeaderContainer page={page} onPageChange={setPage} onPageTitleChange={setPageTitle} />
-      <Divider />
-      <BodyContainer page={page} pageTitle={pageTitle} />
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path='*' element={
+          <div className='App'>
+            <HeaderContainer page={page} onPageChange={setPage} onPageTitleChange={setPageTitle} />
+            <Divider />
+            <BodyContainer page={page} pageTitle={pageTitle} />
+          </div>
+        } />
+        <Route path={ROUTES.ARTICLES} element={
+          <Articles pageTitle={ARTICLES_PAGE_TITLE} />
+        } />
+        <Route path={ROUTES.ADD_ARTICLE} element={
+          <AddArticle pageTitle={ADD_ARTICLE_PAGE_TITLE} />
+        } />
+        <Route path={ROUTES.PROFILE} element={
+          <Profile pageTitle={PROFILE_PAGE_TITLE} />
+        } />
+      </Routes>
+
+    </BrowserRouter>
   )
 }
 

--- a/front/src/components/articles/addArticle.js
+++ b/front/src/components/articles/addArticle.js
@@ -1,11 +1,10 @@
-import Typography from '@mui/material/Typography'
+import { PageTitle } from '../pageTitle/pageTitle'
+import { Container } from '@mui/material'
 
 export function AddArticle({ pageTitle }) {
   return (
-    <div>
-      <Typography gutterBottom variant='h4' component='div' mt={3}>
-        {pageTitle}
-      </Typography>
-    </div>
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <PageTitle pageTitle={pageTitle} />
+    </Container>
   )
 }

--- a/front/src/components/articles/articles.js
+++ b/front/src/components/articles/articles.js
@@ -1,12 +1,11 @@
 import { PostContainer } from '../../containers/post/post'
-import Typography from '@mui/material/Typography'
+import { PageTitle } from '../pageTitle/pageTitle'
+import { Container } from '@mui/material'
 
 export function Articles({ pageTitle }) {
   return (
-    <div>
-      <Typography gutterBottom variant='h4' component='div' mt={3}>
-        {pageTitle}
-      </Typography>
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <PageTitle pageTitle={pageTitle} />
       <PostContainer
         subject='First post'
         body='The first post in CozyTalk social network.
@@ -16,6 +15,6 @@ export function Articles({ pageTitle }) {
                       other people in community who view your page.'
         tags={['first post', 'post', 'cozy talk', 'news']}
       />
-    </div>
+    </Container>
   )
 }

--- a/front/src/components/pageTitle/pageTitle.js
+++ b/front/src/components/pageTitle/pageTitle.js
@@ -1,0 +1,9 @@
+import Typography from '@mui/material/Typography'
+
+export function PageTitle({ pageTitle }) {
+  return (
+    <Typography gutterBottom variant='h4' component='div' mt={3}>
+      {pageTitle}
+    </Typography>
+  )
+}

--- a/front/src/components/pages/notFound.js
+++ b/front/src/components/pages/notFound.js
@@ -1,0 +1,10 @@
+import { PageTitle } from '../pageTitle/pageTitle'
+import { Container } from '@mui/material'
+
+export function NotFound() {
+  return (
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <PageTitle pageTitle={'404 Page not found :('} />
+    </Container>
+  )
+}

--- a/front/src/components/pages/postRoute.js
+++ b/front/src/components/pages/postRoute.js
@@ -1,0 +1,14 @@
+import { PageTitle } from '../pageTitle/pageTitle'
+import { Container } from '@mui/material'
+import Typography from '@mui/material/Typography'
+
+export function PostRoute({ title, body }) {
+  return (
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <PageTitle pageTitle={title} />
+      <Typography variant='h5' fontStyle={'italic'}>
+        {body}
+      </Typography>
+    </Container>
+  )
+}

--- a/front/src/components/pages/routeMatch.js
+++ b/front/src/components/pages/routeMatch.js
@@ -2,7 +2,7 @@ import { PageTitle } from '../pageTitle/pageTitle'
 import { Container } from '@mui/material'
 import Typography from '@mui/material/Typography'
 
-export function PostRoute({ title, body }) {
+export function RouteMatch({ title, body }) {
   return (
     <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
       <PageTitle pageTitle={title} />

--- a/front/src/components/post/post.js
+++ b/front/src/components/post/post.js
@@ -1,11 +1,12 @@
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
+import { Container } from '@mui/material'
 
 export function Post({ subject, body, tags }) {
   return (
-    <div>
-      <Card variant='outlined' sx={{ maxWidth: 350, margin: 'auto' }}>
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <Card variant='outlined' maxWidth='sm'>
         <CardContent>
           <Typography gutterBottom variant='h5' component='div'>
             {subject}
@@ -18,6 +19,6 @@ export function Post({ subject, body, tags }) {
           </Typography>
         </CardContent>
       </Card>
-    </div>
+    </Container>
   )
 }

--- a/front/src/components/profile/profile.js
+++ b/front/src/components/profile/profile.js
@@ -1,11 +1,10 @@
-import Typography from '@mui/material/Typography'
+import { PageTitle } from '../pageTitle/pageTitle'
+import { Container } from '@mui/material'
 
 export function Profile({ pageTitle }) {
   return (
-    <div>
-      <Typography gutterBottom variant='h4' component='div' mt={3}>
-        {pageTitle}
-      </Typography>
-    </div>
+    <Container maxWidth='sm' sx={{ textAlign: 'center' }}>
+      <PageTitle pageTitle={pageTitle} />
+    </Container>
   )
 }

--- a/front/src/containers/post/dateRoute.js
+++ b/front/src/containers/post/dateRoute.js
@@ -16,7 +16,7 @@ export function DateRouteContainer() {
   }
 
   const dateInPast = (date) => {
-    return new Date(date).setDate(new Date(date).getDate() + 1) < Date.now()
+    return new Date(date) < new Date().setDate(new Date().getDate() - 1)
   }
 
   if (matchDateFrom(date) && dateInPast(date)) {

--- a/front/src/containers/post/dateRoute.js
+++ b/front/src/containers/post/dateRoute.js
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom'
+import { RouteMatch } from '../../components/pages/routeMatch'
+import { NotFound } from '../../components/pages/notFound'
+
+export function DateRouteContainer() {
+
+  const PAGE_TITLES = {
+    DATE_IN_PAST: 'Date in the past'
+  }
+
+  const { date } = useParams()
+
+  const matchDateFrom = (input) => {
+    const match = input.match(/^\d{4}[\-](0[1-9]|1[0-2])[\-](0[1-9]|[1-2][0-9]|3[0-1])$/)
+    return match && match[0] && match[0] === input
+  }
+
+  const dateInPast = (date) => {
+    return new Date(date).setDate(new Date(date).getDate() + 1) < Date.now()
+  }
+
+  if (matchDateFrom(date) && dateInPast(date)) {
+    return <RouteMatch title={PAGE_TITLES.DATE_IN_PAST} body={date} />
+  }
+
+  return <NotFound />
+}

--- a/front/src/containers/post/postRoute.js
+++ b/front/src/containers/post/postRoute.js
@@ -1,0 +1,40 @@
+import { useParams } from 'react-router-dom'
+import { PostRoute } from '../../components/pages/postRoute'
+import { NotFound } from '../../components/pages/notFound'
+
+export function PostRouteContainer() {
+
+  const PAGE_TITLES = {
+    NUMERIC_ID: 'Post with numeric ID',
+    CAPITAL_LETTERS_ID: 'Post with capital letters ID',
+    FILENAME_WITH_EXT_ID: 'POST with filename.ext'
+  }
+
+  const { id } = useParams()
+
+  const matchNumericString = (input) => {
+    const match = input.match(/\d+/)
+    return match && match[0] && match[0] === input
+  }
+
+  const matchCapitalString = (input) => {
+    const match = input.match(/^[A-Z]+$/)
+    return match && match[0] && match[0] === input
+  }
+
+  const matchFilenameWithExtensionString = (input) => {
+    const match = input.match(/^[0-9a-zA-Z]+\.(doc|pdf|jpeg)$/)
+    return match && match[0] && match[0] === input
+  }
+
+  if (matchNumericString(id)) {
+    return <PostRoute title={PAGE_TITLES.NUMERIC_ID} body={id} />
+  }
+  if (matchCapitalString(id)) {
+    return <PostRoute title={PAGE_TITLES.CAPITAL_LETTERS_ID} body={id} />
+  }
+  if (matchFilenameWithExtensionString(id)) {
+    return <PostRoute title={PAGE_TITLES.FILENAME_WITH_EXT_ID} body={id} />
+  }
+  return <NotFound />
+}

--- a/front/src/containers/post/postRoute.js
+++ b/front/src/containers/post/postRoute.js
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom'
-import { PostRoute } from '../../components/pages/postRoute'
+import { RouteMatch } from '../../components/pages/routeMatch'
 import { NotFound } from '../../components/pages/notFound'
 
 export function PostRouteContainer() {
@@ -28,13 +28,13 @@ export function PostRouteContainer() {
   }
 
   if (matchNumericString(id)) {
-    return <PostRoute title={PAGE_TITLES.NUMERIC_ID} body={id} />
+    return <RouteMatch title={PAGE_TITLES.NUMERIC_ID} body={id} />
   }
   if (matchCapitalString(id)) {
-    return <PostRoute title={PAGE_TITLES.CAPITAL_LETTERS_ID} body={id} />
+    return <RouteMatch title={PAGE_TITLES.CAPITAL_LETTERS_ID} body={id} />
   }
   if (matchFilenameWithExtensionString(id)) {
-    return <PostRoute title={PAGE_TITLES.FILENAME_WITH_EXT_ID} body={id} />
+    return <RouteMatch title={PAGE_TITLES.FILENAME_WITH_EXT_ID} body={id} />
   }
   return <NotFound />
 }


### PR DESCRIPTION
* Add routes for pages:
  * "/" - default path with Header and Body components
  * /articles for the Articles page
  * /addArticle for the AddArticle page
  * /profile for the Profile page
* Add post routes.
Allow /post/:id, where id is:
  * numeric string
  * capital letters string
  * filename with a hardcoded list of extensions
* Add a date in the past route.
Allow /date/:date, where the date is
in the past and has the following
format: "YYYY-MM-DD".
* Redirect the rest of the requests not matching
patterns to the NotFound page.